### PR TITLE
Fix framework-init for Windows and Mac OS before X

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ import { exec } from 'child_process';
 const getNpmPackages = (nodeModulesPath) => {
     return new Promise<string[]>((resolve) => {
         exec(`npm ls -a -p`, { cwd: nodeModulesPath, }, function (error, stdout, stderr) {
-            resolve(stdout ? stdout.split('\n').filter(x => path.isAbsolute(x)) : [])
+            resolve(stdout ? stdout.split(/\r\n|\n|\r/).filter(x => path.isAbsolute(x)) : [])
         });
     });
 }

--- a/packages/core/tests/index.spec.ts
+++ b/packages/core/tests/index.spec.ts
@@ -20,7 +20,7 @@ describe('', () => {
         const elementPaths = await getElementsScriptPaths({ nodeModulesPath: path.join(__dirname, '../../framework/node_modules') });
         const pathsWithRelativeRemoved = {};
         for (const element of Object.keys(elementPaths)) {
-            pathsWithRelativeRemoved[element] = path.relative(__dirname, elementPaths[element]);
+            pathsWithRelativeRemoved[element] = path.relative(__dirname, elementPaths[element]).replaceAll('\\', '/');
         }
         expect(pathsWithRelativeRemoved).toMatchSnapshot();
     });


### PR DESCRIPTION
On Windows OS how to setup drayman:
- npx @drayman/framework-init@latest my-app
- cd my-app
- npm start

Got this error:
> my-app@0.0.0 start
> drayman-framework start

>node:internal/process/promises:246
>          triggerUncaughtException(err, true /* fromPromise */);
>          ^

>\package.json'] {o such file or directory, open 'C:\Users\someuser\Desktop\test\my-app
> errno: -4058,
>  code: 'ENOENT',
>  syscall: 'open',
>  path: 'C:\\Users\\someuser\\Desktop\\test\\my-app\r\\package.json'
>}

This PR contain fix for this situation! 